### PR TITLE
Ast-43-fix-add-event-screen

### DIFF
--- a/client/client-app/App.js
+++ b/client/client-app/App.js
@@ -1,6 +1,7 @@
 import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import EditEvent from './EditEvent';
+import AddEvent from './AddEvent';
 import Login from "./Login";
 import TabRoot from "./TabRoot";
 
@@ -18,6 +19,7 @@ function App() {
         <Stack.Screen name="Login" component={Login} />
         <Stack.Screen name="TabRoot" component={TabRoot} />
         <Stack.Screen name="EditEvent" component={EditEvent} />
+        <Stack.Screen name="AddEvent" component={AddEvent} />
       </Stack.Navigator>
     </NavigationContainer>
   );


### PR DESCRIPTION
This PR fixes a bug that caused app to crash when user clicks 'Add Event' from the events tab.

Repro instructions: Use expo go, navigate to events, click Add Event, see that Add Event screen shows up